### PR TITLE
[WIP] Remove hadron-reflux-store and use AppRegistry to access NamespaceStore

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -30,7 +30,10 @@ const ValidationStore = Reflux.createStore({
    */
   init() {
     this.lastFetchedValidatorDoc = {};
-    this.NamespaceStore = app.appRegistry.getStore('App.NamespaceStore');
+  },
+
+  onActivated(appRegistry) {
+    this.NamespaceStore = appRegistry.getStore('App.NamespaceStore');
   },
 
   onCollectionChanged(ns) {


### PR DESCRIPTION
Just a few quick changes, should be ticketed.